### PR TITLE
#minor feat: differentiate between configs being published and not

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "insta",
+ "test-case",
  "toml_edit",
 ]
 
@@ -80,6 +81,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -343,6 +350,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cad0a06f9a61e94355aa3b3dc92d85ab9c83406722b1ca5e918d4297c12c23"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +416,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ toml_edit = "0.2.1"
 
 [dev-dependencies]
 insta = "1.7.1"
+test-case = "1.2.1"

--- a/src/snapshots/cargo_funnel__util__util_test__sort_package_fields_test__only_requires_name_and_version_if_publish_false.snap
+++ b/src/snapshots/cargo_funnel__util__util_test__sort_package_fields_test__only_requires_name_and_version_if_publish_false.snap
@@ -1,0 +1,11 @@
+---
+source: src/util.rs
+expression: "format!(\"{}\", toml.to_string())"
+
+---
+
+[package]
+name = "overwhelmed"
+version = "1.0.0"
+publish = false
+            


### PR DESCRIPTION
only require name and version for things not being published to crates.io